### PR TITLE
Bump PSDocs version to v0.9.0-B2107020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=0.9.0-B2107015
+ARG MODULE_VERSION=0.9.0-B2107020
 
 # NOTE: Use pre-release version with -MinimumVersion -AllowPrerelease.
 

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -176,7 +176,7 @@ try {
     Invoke-PSDocument @invokeParams -InputPath $InputPath;
 }
 catch {
-    Write-Host "::error::An error occured generating documentation.";
+    Write-Host "::error::An error occured generating documentation. $($_.Exception.Message)";
     $Host.SetShouldExit(1);
 }
 finally {


### PR DESCRIPTION
## PR Summary

- Bumped PSDocs version to v0.9.0-B2107020.
- Log exception error message in Actions log.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
